### PR TITLE
Fix task list formatting on multiple line tasks

### DIFF
--- a/source/homepage/homepage.css
+++ b/source/homepage/homepage.css
@@ -154,6 +154,12 @@ button:hover {
   min-width: 80%;
   border: none;
   padding: 4px;
+
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 /* Styling when editing a task */
@@ -170,6 +176,13 @@ button:hover {
     border: var(--accent-color) solid 1px;
     border-radius: 0.6em;
     box-shadow: 0 0 5px #719ECE;
+
+		word-break: break-all;
+		
+		-webkit-line-clamp: unset;
+		-webkit-box-orient: unset;
+		overflow: unset;
+		text-overflow: unset;
   }
 }
 


### PR DESCRIPTION
Tasks were not wrapping properly and displaying more text than they should when task names are longer than 2 lines. Fixed this through css styling of task-input.